### PR TITLE
.gitignore: add ._DS_Store for Mac Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *~
 .idea
+._DS_Store


### PR DESCRIPTION
Mac creates .DS_Store files for auto indexing.
These should be ignored.
